### PR TITLE
Atlantis add aws

### DIFF
--- a/atlantis/Dockerfile
+++ b/atlantis/Dockerfile
@@ -13,12 +13,19 @@ RUN curl -LO "https://github.com/gruntwork-io/terragrunt/releases/download/v$TER
     && chmod +x ./terragrunt_linux_amd64 \
     && mv ./terragrunt_linux_amd64 /usr/local/bin/terragrunt
 
-RUN apk add --no-cache \
-    python3 \
-    py3-pip \
-    && pip3 install --upgrade pip \
-    && pip3 install \
-    awscli \
-    && rm -rf /var/cache/apk/*
+# https://github.com/aws/aws-cli/issues/4685
+ENV GLIBC_VER=2.33-r0
+
+RUN curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk \
+    && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
+    && apk add --update --no-cache util-linux openssl python3 glibc-${GLIBC_VER}.apk glibc-bin-${GLIBC_VER}.apk \
+    && unzip awscliv2.zip && aws/install \
+    && rm -rf awscliv2.zip aws glibc-${GLIBC_VER}.apk glibc-bin-${GLIBC_VER}.apk \
+    /usr/local/aws-cli/v2/*/dist/aws_completer \
+    /usr/local/aws-cli/v2/*/dist/awscli/data/ac.index \
+    /usr/local/aws-cli/v2/*/dist/awscli/examples \
+    /var/cache/apk/*
 
 RUN chmod +x /usr/local/bin/terragrunt

--- a/atlantis/Dockerfile
+++ b/atlantis/Dockerfile
@@ -13,4 +13,12 @@ RUN curl -LO "https://github.com/gruntwork-io/terragrunt/releases/download/v$TER
     && chmod +x ./terragrunt_linux_amd64 \
     && mv ./terragrunt_linux_amd64 /usr/local/bin/terragrunt
 
+RUN apk add --no-cache \
+    python3 \
+    py3-pip \
+    && pip3 install --upgrade pip \
+    && pip3 install \
+    awscli \
+    && rm -rf /var/cache/apk/*
+
 RUN chmod +x /usr/local/bin/terragrunt


### PR DESCRIPTION
- add aws cli to the atlantis, so that we can exec into EKS cluster to get token as noted [here](https://github.com/cloudposse/terraform-aws-eks-cluster)
- context: we need to exec into EKS and validate aws-auth configmap